### PR TITLE
feat: real-time oscillator synthesis with sample upload and recording

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,70 @@
+# Vangelis - Web MIDI Synthesizer
+
+A browser-based synthesizer with real-time sound generation, custom sample support, and recording capabilities.
+
+## Project Vision
+
+Vangelis is an expressive, playable web synthesizer that feels responsive and musical. The core goals are:
+
+1. **Real-time synthesis** - Notes respond instantly with proper attack/decay/sustain/release controlled by key press and release
+2. **Custom sounds** - Users can upload their own audio samples to play via the keyboard
+3. **Recording** - Capture performances and auto-download as audio files
+
+## Architecture
+
+### Sound Engine (`/sound-engine`)
+- **Rust/WASM** (`audio-engine/`) - High-performance waveform generation with PolyBLEP anti-aliasing
+- **Frontend** (`frontend/`) - React app with Web Audio API integration
+
+### Audio Pipeline
+```
+OscillatorNode/AudioBufferSource
+    -> GainNode (per-voice envelope)
+    -> Compressor
+    -> Distortion
+    -> Delay
+    -> Reverb
+    -> Master Gain
+    -> Panner
+    -> Destination/MediaRecorder
+```
+
+## Key Features
+
+### Real-time Synthesis
+- Uses native Web Audio OscillatorNode for basic waveforms (sine, square, sawtooth, triangle)
+- True ADSR envelope: attack/decay on key down, release on key up
+- Notes sustain for as long as keys are held
+
+### Custom Sample Mode
+- Upload WAV/MP3/OGG files as custom instruments
+- Samples mapped across keyboard with pitch shifting
+- Supports one-shot and looped playback
+
+### Recording
+- Record button captures all audio output
+- Automatic download when recording stops
+- Exports as WAV format
+
+## Development
+
+```bash
+cd sound-engine/frontend
+npm install
+npm run dev
+```
+
+Build WASM module:
+```bash
+cd sound-engine/audio-engine
+wasm-pack build --target web
+```
+
+## Keyboard Controls
+
+| Key | Action |
+|-----|--------|
+| A-; | White keys (C to F) |
+| W-P | Black keys (sharps) |
+| Z/X | Octave down/up |
+| Space | Toggle recording |

--- a/sound-engine/frontend/src/App.jsx
+++ b/sound-engine/frontend/src/App.jsx
@@ -1,10 +1,11 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect, useRef, useCallback } from 'react';
 import SynthKeyboard from './components/SynthKeyboard';
 import AudioControls from './components/AudioControls';
 import UIOverlay from './components/UIOverlay';
 import ErrorBoundary from './components/ErrorBoundary';
 import Scene from './components/Scene';
 import { audioEngine } from './utils/audioEngine.js';
+import { loadCustomSample, clearCustomSample, toggleRecording } from './utils/audio.js';
 
 const App = () => {
   const [engineStatus, setEngineStatus] = useState(() => audioEngine.getStatus());
@@ -26,6 +27,10 @@ const App = () => {
     phaseOffset: 0
   });
   const [showShortcuts, setShowShortcuts] = useState(false);
+  const [isRecording, setIsRecording] = useState(false);
+  const [sampleInfo, setSampleInfo] = useState(null);
+  const [sampleLoading, setSampleLoading] = useState(false);
+  const fileInputRef = useRef(null);
   const scrollRaf = useRef(null);
   const wasmLoaded = engineStatus.wasmReady;
   const isGraphWarm = engineStatus.graphWarmed;
@@ -36,13 +41,50 @@ const App = () => {
 
   useEffect(() => {
     const unsubscribe = audioEngine.subscribe(setEngineStatus);
+    const unsubRecording = audioEngine.subscribeRecording(setIsRecording);
 
     audioEngine.ensureWasm().catch(() => {});
     audioEngine.ensureAudioContext().then(() => {
       audioEngine.warmGraph();
     });
 
-    return unsubscribe;
+    return () => {
+      unsubscribe();
+      unsubRecording();
+    };
+  }, []);
+
+  // Handle sample file upload
+  const handleFileSelect = useCallback(async (event) => {
+    const file = event.target.files?.[0];
+    if (!file) return;
+
+    setSampleLoading(true);
+    try {
+      const info = await loadCustomSample(file);
+      setSampleInfo({
+        name: file.name,
+        duration: info.duration.toFixed(2),
+        channels: info.channels
+      });
+    } catch (err) {
+      console.error('Failed to load sample:', err);
+      alert('Failed to load audio file. Please try a different file.');
+    } finally {
+      setSampleLoading(false);
+    }
+  }, []);
+
+  const handleClearSample = useCallback(() => {
+    clearCustomSample();
+    setSampleInfo(null);
+    if (fileInputRef.current) {
+      fileInputRef.current.value = '';
+    }
+  }, []);
+
+  const handleRecordToggle = useCallback(() => {
+    toggleRecording();
   }, []);
 
   useEffect(() => {
@@ -54,6 +96,12 @@ const App = () => {
 
       if (event.key === 'Escape') {
         setShowShortcuts(false);
+      }
+
+      // Space bar toggles recording (only if not focused on input)
+      if (event.key === ' ' && event.target.tagName !== 'INPUT' && event.target.tagName !== 'BUTTON') {
+        event.preventDefault();
+        toggleRecording();
       }
     };
 
@@ -102,21 +150,65 @@ const App = () => {
         <div className="app-shell">
         <header className="zone-top tier-subtle content-tertiary" aria-label="Branding and quick actions">
           <div className="brand-title">Vangelis</div>
-          <button
-            type="button"
-            className="button-icon"
-            aria-label="View keyboard shortcuts"
-            onClick={() => setShowShortcuts(true)}
-          >
-            <span aria-hidden="true">?</span>
-          </button>
+          <div className="header-controls">
+            {/* Sample Upload */}
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept="audio/*"
+              onChange={handleFileSelect}
+              style={{ display: 'none' }}
+              id="sample-upload"
+            />
+            <label
+              htmlFor="sample-upload"
+              className={`button-icon ${sampleLoading ? 'loading' : ''}`}
+              title={sampleInfo ? `Sample: ${sampleInfo.name}` : 'Upload custom sample'}
+            >
+              <span aria-hidden="true">{sampleInfo ? '!' : '+'}</span>
+            </label>
+            {sampleInfo && (
+              <button
+                type="button"
+                className="button-icon"
+                onClick={handleClearSample}
+                title="Clear sample"
+                aria-label="Clear custom sample"
+              >
+                <span aria-hidden="true">x</span>
+              </button>
+            )}
+
+            {/* Recording Button */}
+            <button
+              type="button"
+              className={`button-icon record-button ${isRecording ? 'recording' : ''}`}
+              onClick={handleRecordToggle}
+              title={isRecording ? 'Stop recording (Space)' : 'Start recording (Space)'}
+              aria-label={isRecording ? 'Stop recording' : 'Start recording'}
+            >
+              <span aria-hidden="true">{isRecording ? '||' : 'O'}</span>
+            </button>
+
+            <button
+              type="button"
+              className="button-icon"
+              aria-label="View keyboard shortcuts"
+              onClick={() => setShowShortcuts(true)}
+            >
+              <span aria-hidden="true">?</span>
+            </button>
+          </div>
         </header>
 
         <main className="zone-center content-primary" aria-label="Keyboard area">
           <div className="keyboard-surface tier-focus" role="region" aria-label="Virtual keyboard">
             <div className="keyboard-header">
               <span>Keyboard</span>
-              <span className="keyboard-legend">Waveform · {waveformType}</span>
+              <span className="keyboard-legend">
+                {sampleInfo ? `Sample: ${sampleInfo.name}` : `Waveform: ${waveformType}`}
+                {isRecording && <span className="recording-indicator"> [REC]</span>}
+              </span>
             </div>
             <div className="keyboard-region">
               <SynthKeyboard

--- a/sound-engine/frontend/src/style.css
+++ b/sound-engine/frontend/src/style.css
@@ -1407,3 +1407,78 @@ input[type="range"]::-moz-range-thumb:active {
   font-size: 0.85rem;
   opacity: 0.5;
 }
+
+/* Header Controls */
+.header-controls {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.header-controls .button-icon {
+  width: 36px;
+  height: 36px;
+  font-size: 0.9rem;
+}
+
+.header-controls label.button-icon {
+  cursor: pointer;
+}
+
+.header-controls .button-icon.loading {
+  opacity: 0.5;
+  pointer-events: none;
+}
+
+/* Recording Button */
+.record-button {
+  position: relative;
+}
+
+.record-button.recording {
+  background: rgba(255, 50, 50, 0.3);
+  border-color: rgba(255, 50, 50, 0.5);
+  animation: recordPulse 1s ease-in-out infinite;
+}
+
+.record-button.recording span {
+  color: rgba(255, 100, 100, 1);
+}
+
+@keyframes recordPulse {
+  0%, 100% {
+    box-shadow: 0 0 0 0 rgba(255, 50, 50, 0.4);
+  }
+  50% {
+    box-shadow: 0 0 0 8px rgba(255, 50, 50, 0);
+  }
+}
+
+/* Recording Indicator in keyboard header */
+.recording-indicator {
+  color: rgba(255, 80, 80, 1);
+  font-weight: 500;
+  animation: blink 1s ease-in-out infinite;
+}
+
+@keyframes blink {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.4; }
+}
+
+/* Keyboard hints */
+.keyboard-hints {
+  display: flex;
+  justify-content: center;
+  gap: var(--space-lg);
+  font-size: clamp(0.65rem, 0.8vw, 0.75rem);
+  color: var(--color-text-tertiary);
+  opacity: 0.7;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.keyboard-hint {
+  display: inline-flex;
+  gap: 4px;
+}

--- a/sound-engine/frontend/src/utils/audio.js
+++ b/sound-engine/frontend/src/utils/audio.js
@@ -21,7 +21,6 @@ export const playNote = (
     noteId: options.noteId,
     frequency,
     waveformType,
-    duration,
     params: audioParams,
     velocity: options.velocity ?? 1
   });
@@ -38,10 +37,18 @@ export const ensureWasmLoaded = () => audioEngine.ensureWasm();
 export const audioEngineInstance = audioEngine;
 
 export const preloadNote = ({ frequency, waveformType, audioParams = {}, duration }) => {
-  return audioEngine.preloadNote({
-    frequency,
-    waveformType,
-    duration,
-    params: audioParams
-  });
+  // No preloading needed for oscillator-based synthesis
+  return Promise.resolve();
 };
+
+// Custom sample functions
+export const loadCustomSample = (file) => audioEngine.loadCustomSample(file);
+export const clearCustomSample = () => audioEngine.clearCustomSample();
+export const setCustomSampleBaseNote = (noteName, octave) => audioEngine.setCustomSampleBaseNote(noteName, octave);
+export const setCustomSampleLoop = (loop) => audioEngine.setCustomSampleLoop(loop);
+
+// Recording functions
+export const startRecording = () => audioEngine.startRecording();
+export const stopRecording = () => audioEngine.stopRecording();
+export const toggleRecording = () => audioEngine.toggleRecording();
+export const subscribeRecording = (listener) => audioEngine.subscribeRecording(listener);


### PR DESCRIPTION
Major improvements to the sound engine:
- Replace pre-generated audio buffers with real-time OscillatorNode synthesis
- Implement true ADSR envelope: attack/decay on key press, release on key release
- Notes now sustain for as long as keys are held
- Add custom sample upload feature with pitch shifting across keyboard
- Add recording functionality with auto-download when stopped
- Space bar toggles recording, + button uploads samples
- Create new CLAUDE.md with updated project vision

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a real-time, polyphonic audio engine with ADSR envelopes, custom sample playback, and built-in recording, replacing pre-generated buffers/WASM-driven playback.
> 
> - **Engine refactor**: Replace precomputed buffers with per-voice `OscillatorNode`/`AudioBufferSource` + per-voice `GainNode` ADSR; voice pool, safe ramps, panning, delay/reverb/distortion, analyser; remove waveform preloading and WASM dependencies (`audioEngine.js`).
> - **Custom samples**: Add `loadCustomSample/clearCustomSample/setCustomSample*` APIs; pitch-shift mapping across keyboard with optional loop.
> - **Recording**: Route master to `MediaStreamDestination` and `MediaRecorder`; `start/stop/toggleRecording`, auto-download on stop; recording state subscriptions.
> - **UI updates**: `App.jsx` adds sample upload/clear and record controls, spacebar toggle, header status; `SynthKeyboard.jsx` uses engine `stopNote` for release and removes preloading; new styles for header/recording (`style.css`).
> - **Docs**: New `CLAUDE.md` outlining vision, pipeline, features, and dev steps.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d99747f43ec1615309084c75935cac0d58bfb192. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->