### PR TITLE
fix: update App.test.jsx mock to include subscribeRecording function

### DIFF
--- a/sound-engine/frontend/src/App.test.jsx
+++ b/sound-engine/frontend/src/App.test.jsx
@@ -7,6 +7,7 @@ vi.mock('./utils/audioEngine.js', () => ({
   audioEngine: {
     getStatus: () => ({ wasmReady: false, graphWarmed: false }),
     subscribe: vi.fn(() => () => {}),
+    subscribeRecording: vi.fn(() => () => {}),
     setGlobalParams: vi.fn(),
     ensureWasm: vi.fn(() => Promise.resolve()),
     ensureAudioContext: vi.fn(() => Promise.resolve()),
@@ -41,7 +42,7 @@ describe('App', () => {
 
   it('shows waveform type', () => {
     render(<App />);
-    expect(screen.getByText(/Waveform ·/)).toBeInTheDocument();
+    expect(screen.getByText(/Waveform:/)).toBeInTheDocument();
   });
 
   it('has keyboard shortcuts button', () => {


### PR DESCRIPTION
The test was failing because the audioEngine mock was missing the subscribeRecording method that App.jsx now uses. Also fixed the waveform text assertion to match the current UI format.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Aligns `App.test.jsx` with current app behavior to restore passing tests.
> 
> - Mocks `audioEngine.subscribeRecording` in `audioEngine.js` test mock
> - Updates waveform text assertion from `Waveform ·` to `Waveform:`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e5d04ab5c3d079561a9505a2aa960fe06dcbee83. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->