### PR TITLE
fix: pass u32 waveform directly to LFO::new instead of Waveform enum

### DIFF
--- a/sound-engine/audio-engine/src/lfo.rs
+++ b/sound-engine/audio-engine/src/lfo.rs
@@ -102,15 +102,7 @@ pub fn wasm_apply_lfo_amplitude(
     waveform: u32,
     sample_rate: f32
 ) {
-    let wf = match waveform {
-        0 => Waveform::Sine,
-        1 => Waveform::Sawtooth,
-        2 => Waveform::Square,
-        3 => Waveform::Triangle,
-        _ => Waveform::Sine,
-    };
-    
-    let lfo = LFO::new(rate, depth, wf, LFOTarget::Amplitude);
+    let lfo = LFO::new(rate, depth, waveform, LFOTarget::Amplitude);
     apply_lfo_amplitude(samples, &lfo, sample_rate);
 }
 


### PR DESCRIPTION
LFO::new expects a u32 and handles the conversion internally. The redundant match block was causing a type mismatch error.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Streamlines LFO waveform handling in the WASM entrypoint by delegating `u32`→`Waveform` conversion to `LFO::new`.
> 
> - In `lfo.rs`, `wasm_apply_lfo_amplitude` now passes `waveform: u32` directly to `LFO::new`, removing the redundant local `match` and relying on the constructor’s internal mapping
> - Keeps modulation behavior unchanged while resolving prior type mismatch and reducing duplication
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1e99cef2f75276f51746ce16b530563cb5feb79e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->