### PR TITLE
fix: disable wasm-opt to avoid WASM feature compatibility errors

### DIFF
--- a/sound-engine/audio-engine/Cargo.toml
+++ b/sound-engine/audio-engine/Cargo.toml
@@ -35,3 +35,6 @@ strip = true
 
 [profile.release.package."*"]
 opt-level = 3
+
+[package.metadata.wasm-pack.profile.release]
+wasm-opt = false


### PR DESCRIPTION
wasm-opt fails with bulk memory and saturating float-to-int operations. Disabling it allows the build to complete successfully.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Disables `wasm-opt` for release builds via Cargo metadata to prevent `wasm-pack` from running post-optimization passes that break on certain WASM features.
> 
> - Adds `[package.metadata.wasm-pack.profile.release]` with `wasm-opt = false` in `sound-engine/audio-engine/Cargo.toml`
> - Build-only change; no Rust code or API behavior modified
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f20a1fede2c28db2cab0441c4a32f6a15f1a98a1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->