### PR TITLE
fix: improve polyphony and audio playback reliability

### DIFF
--- a/sound-engine/frontend/src/App.jsx
+++ b/sound-engine/frontend/src/App.jsx
@@ -11,15 +11,15 @@ const App = () => {
   const [engineStatus, setEngineStatus] = useState(() => audioEngine.getStatus());
   const [waveformType, setWaveformType] = useState('Triangle');
   const [audioParams, setAudioParams] = useState({
-    reverb: 0.6,
-    delay: 180,
+    reverb: 0.3,
+    delay: 0,
     distortion: 0,
-    volume: 0.55,
+    volume: 0.7,
     useADSR: true,
-    attack: 0.6,
-    decay: 0.25,
-    sustain: 0.7,
-    release: 1.5,
+    attack: 0.01,
+    decay: 0.1,
+    sustain: 0.8,
+    release: 0.3,
     useFM: false,
     fmRatio: 2,
     fmIndex: 2,

--- a/sound-engine/frontend/src/utils/audioEngine.js
+++ b/sound-engine/frontend/src/utils/audioEngine.js
@@ -473,13 +473,13 @@ class AudioEngine {
     const inputBus = ctx.createGain();
     inputBus.gain.value = 1;
 
-    // Compressor for dynamics control
+    // Compressor for dynamics control (gentle settings to avoid killing quiet sounds)
     const compressor = ctx.createDynamicsCompressor();
-    compressor.threshold.value = -18;
-    compressor.knee.value = 24;
-    compressor.ratio.value = 4;
+    compressor.threshold.value = -6;
+    compressor.knee.value = 30;
+    compressor.ratio.value = 2;
     compressor.attack.value = 0.003;
-    compressor.release.value = 0.1;
+    compressor.release.value = 0.25;
 
     // Distortion
     const distortion = ctx.createWaveShaper();
@@ -609,9 +609,11 @@ class AudioEngine {
   }
 
   recycleVoice(voice) {
+    // Clean up any stale references (voice might already be removed from activeVoices)
     if (voice.noteId && this.activeVoices.get(voice.noteId) === voice) {
       this.activeVoices.delete(voice.noteId);
     }
+    voice.noteId = null;
 
     if (!this.freeVoices.includes(voice)) {
       this.freeVoices.push(voice);
@@ -778,6 +780,8 @@ class AudioEngine {
   stopNote(noteId) {
     const voice = this.activeVoices.get(noteId);
     if (voice) {
+      // Remove from activeVoices immediately so the note can be replayed
+      this.activeVoices.delete(noteId);
       const releaseTime = this.currentParams?.release ?? 0.3;
       voice.release(releaseTime);
     }


### PR DESCRIPTION
- Remove voice from activeVoices immediately on note release, allowing rapid retriggering of the same note
- Reduce compressor aggressiveness (-6dB threshold, 2:1 ratio) to avoid killing quiet sounds
- Fix default audio params: attack 10ms (was 600ms), release 300ms, higher volume, no delay by default
- Clear voice noteId on recycle to prevent stale references

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Polyphony and playback reliability**
> 
> - Remove notes from `activeVoices` immediately in `stopNote` and clear `voice.noteId` in `recycleVoice` to prevent stale refs and enable rapid retriggering
> - Soften dynamics processing: compressor threshold `-6dB`, knee `30`, ratio `2:1`, longer release
> - Update default synth params in `App.jsx`: faster ADSR (`attack 0.01`, `decay 0.1`, `sustain 0.8`, `release 0.3`), `volume 0.7`, `reverb 0.3`, `delay 0`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4c2f3abb238cefa375d8264e2acc33d7d3fc0e05. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->