### PR TITLE
Default instrument layers

### DIFF
--- a/sound-engine/frontend/src/components/Sidebar/MidiTab.jsx
+++ b/sound-engine/frontend/src/components/Sidebar/MidiTab.jsx
@@ -42,7 +42,14 @@ const MidiTab = ({
 
     try {
       const midiData = await loadMidiWithFallback(file);
-      onPlay(midiData);
+      onPlay({
+        ...midiData,
+        name: file.name || midiData.name,
+        sourceFileId: file.id,
+        composer: file.composer,
+        soundSetId: file.soundSetId || null,
+        layerFamilies: Array.isArray(file.layerFamilies) ? file.layerFamilies : []
+      });
     } catch (err) {
       console.error('Failed to load MIDI file:', err);
       setError(file.sourceUrl

--- a/sound-engine/frontend/src/components/Sidebar/MidiTab.test.jsx
+++ b/sound-engine/frontend/src/components/Sidebar/MidiTab.test.jsx
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import MidiTab from './MidiTab.jsx';
+import { parseMidiFile, getBuiltInMidiFiles } from '../../utils/midiParser.js';
+
+vi.mock('../../utils/midiParser.js', () => ({
+  parseMidiFile: vi.fn(),
+  getBuiltInMidiFiles: vi.fn()
+}));
+
+const defaultProps = (overrides = {}) => ({
+  isPlaying: false,
+  isPaused: false,
+  progress: 0,
+  currentMidi: null,
+  tempoFactor: 1,
+  onPlay: vi.fn(),
+  onPause: vi.fn(),
+  onResume: vi.fn(),
+  onStop: vi.fn(),
+  onTempoChange: vi.fn(),
+  ...overrides
+});
+
+describe('MidiTab', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getBuiltInMidiFiles.mockReturnValue([
+      {
+        id: 'rachmaninoff-concerto2-mov1',
+        name: 'Piano Concerto No. 2 - I. Moderato',
+        path: '/midi/rachmaninoff-concerto2-mov1.mid',
+        composer: 'Sergei Rachmaninoff',
+        soundSetId: 'rachmaninoff-orchestral-lite',
+        layerFamilies: ['piano', 'strings']
+      }
+    ]);
+    parseMidiFile.mockResolvedValue({
+      name: 'Embedded MIDI Name',
+      duration: 1.2,
+      bpm: 110,
+      notes: [{ midi: 60, time: 0, duration: 0.3, velocity: 0.9 }]
+    });
+  });
+
+  it('forwards built-in layering metadata into playback payload', async () => {
+    const onPlay = vi.fn();
+    render(<MidiTab {...defaultProps({ onPlay })} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /piano concerto no\. 2 - i\. moderato/i }));
+
+    await waitFor(() => {
+      expect(onPlay).toHaveBeenCalledTimes(1);
+    });
+
+    expect(parseMidiFile).toHaveBeenCalledWith('/midi/rachmaninoff-concerto2-mov1.mid');
+    expect(onPlay).toHaveBeenCalledWith(expect.objectContaining({
+      name: 'Piano Concerto No. 2 - I. Moderato',
+      sourceFileId: 'rachmaninoff-concerto2-mov1',
+      composer: 'Sergei Rachmaninoff',
+      soundSetId: 'rachmaninoff-orchestral-lite',
+      layerFamilies: ['piano', 'strings']
+    }));
+  });
+
+  it('plays uploaded MIDI files without forcing library metadata', async () => {
+    const onPlay = vi.fn();
+    render(<MidiTab {...defaultProps({ onPlay })} />);
+
+    const input = screen.getByLabelText(/choose midi file/i);
+    const upload = new File([new Uint8Array([0x4d, 0x54, 0x68, 0x64])], 'custom.mid', { type: 'audio/midi' });
+    fireEvent.change(input, { target: { files: [upload] } });
+
+    await waitFor(() => {
+      expect(onPlay).toHaveBeenCalledTimes(1);
+    });
+
+    expect(parseMidiFile).toHaveBeenCalledWith(upload);
+    expect(onPlay).toHaveBeenCalledWith(expect.objectContaining({
+      name: 'Embedded MIDI Name'
+    }));
+    expect(onPlay.mock.calls[0][0].soundSetId).toBeUndefined();
+    expect(onPlay.mock.calls[0][0].layerFamilies).toBeUndefined();
+  });
+});

--- a/sound-engine/frontend/src/hooks/useMidiPlayback.test.js
+++ b/sound-engine/frontend/src/hooks/useMidiPlayback.test.js
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { useMidiPlayback } from './useMidiPlayback.js';
+import { audioEngine } from '../utils/audioEngine.js';
+import { ensureSoundSetLoaded } from '../utils/instrumentSamples.js';
+
+vi.mock('../utils/audioEngine.js', () => ({
+  audioEngine: {
+    context: { currentTime: 0 },
+    ensureAudioContext: vi.fn(),
+    playBufferedSample: vi.fn(),
+    playFrequency: vi.fn(),
+    stopNote: vi.fn()
+  }
+}));
+
+vi.mock('../utils/instrumentSamples.js', () => ({
+  ensureSoundSetLoaded: vi.fn()
+}));
+
+describe('useMidiPlayback layering', () => {
+  const originalRequestAnimationFrame = global.requestAnimationFrame;
+  const originalCancelAnimationFrame = global.cancelAnimationFrame;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+    audioEngine.context = { currentTime: 0 };
+    audioEngine.ensureAudioContext.mockResolvedValue(audioEngine.context);
+    audioEngine.playBufferedSample.mockImplementation(({ noteId }) => ({ voiceId: noteId }));
+    audioEngine.playFrequency.mockImplementation(({ noteId }) => ({ voiceId: noteId }));
+    global.requestAnimationFrame = vi.fn(() => 1);
+    global.cancelAnimationFrame = vi.fn();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    global.requestAnimationFrame = originalRequestAnimationFrame;
+    global.cancelAnimationFrame = originalCancelAnimationFrame;
+  });
+
+  it('plays stacked sample layers when a sound set is available', async () => {
+    ensureSoundSetLoaded.mockResolvedValue({
+      id: 'rachmaninoff-orchestral-lite',
+      pickInstruments: () => [
+        { id: 'piano', buffer: {}, baseFrequency: 261.63 },
+        { id: 'violin', buffer: {}, baseFrequency: 196.0 }
+      ]
+    });
+
+    const { result } = renderHook(() => useMidiPlayback({
+      waveformType: 'sine',
+      audioParams: { volume: 0.7, attack: 0.01, decay: 0.1, sustain: 0.7, release: 0.3 }
+    }));
+
+    await act(async () => {
+      result.current.play({
+        duration: 1,
+        bpm: 120,
+        notes: [{ midi: 60, time: 0, duration: 0.1, velocity: 1, instrumentFamily: 'piano' }],
+        soundSetId: 'rachmaninoff-orchestral-lite',
+        layerFamilies: ['piano', 'strings']
+      });
+    });
+
+    await waitFor(() => {
+      expect(ensureSoundSetLoaded).toHaveBeenCalledWith('rachmaninoff-orchestral-lite');
+    });
+
+    await act(async () => {
+      vi.runAllTimers();
+    });
+
+    expect(audioEngine.playBufferedSample).toHaveBeenCalledTimes(2);
+    expect(audioEngine.playFrequency).not.toHaveBeenCalled();
+    expect(audioEngine.stopNote).toHaveBeenCalledTimes(2);
+  });
+
+  it('falls back to waveform layer families when sample set is unavailable', async () => {
+    ensureSoundSetLoaded.mockResolvedValue(null);
+
+    const { result } = renderHook(() => useMidiPlayback({
+      waveformType: 'sine',
+      audioParams: { volume: 0.7, attack: 0.01, decay: 0.1, sustain: 0.7, release: 0.3 }
+    }));
+
+    await act(async () => {
+      result.current.play({
+        duration: 1,
+        bpm: 120,
+        notes: [{ midi: 64, time: 0, duration: 0.1, velocity: 0.8, instrumentFamily: 'piano' }],
+        soundSetId: 'rachmaninoff-orchestral-lite',
+        layerFamilies: ['piano', 'strings']
+      });
+    });
+
+    await waitFor(() => {
+      expect(ensureSoundSetLoaded).toHaveBeenCalledWith('rachmaninoff-orchestral-lite');
+    });
+
+    await act(async () => {
+      vi.runAllTimers();
+    });
+
+    expect(audioEngine.playBufferedSample).not.toHaveBeenCalled();
+    expect(audioEngine.playFrequency).toHaveBeenCalledTimes(2);
+
+    const waveforms = audioEngine.playFrequency.mock.calls.map((call) => call[0].waveformType);
+    expect(waveforms).toContain('triangle');
+    expect(waveforms).toContain('saw');
+  });
+});

--- a/sound-engine/frontend/src/hooks/useMidiPlayback.test.js
+++ b/sound-engine/frontend/src/hooks/useMidiPlayback.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { renderHook, act, waitFor } from '@testing-library/react';
+import { renderHook, act } from '@testing-library/react';
 import { useMidiPlayback } from './useMidiPlayback.js';
 import { audioEngine } from '../utils/audioEngine.js';
 import { ensureSoundSetLoaded } from '../utils/instrumentSamples.js';
@@ -61,11 +61,11 @@ describe('useMidiPlayback layering', () => {
         soundSetId: 'rachmaninoff-orchestral-lite',
         layerFamilies: ['piano', 'strings']
       });
+      await Promise.resolve();
+      await Promise.resolve();
     });
 
-    await waitFor(() => {
-      expect(ensureSoundSetLoaded).toHaveBeenCalledWith('rachmaninoff-orchestral-lite');
-    });
+    expect(ensureSoundSetLoaded).toHaveBeenCalledWith('rachmaninoff-orchestral-lite');
 
     await act(async () => {
       vi.runAllTimers();
@@ -92,11 +92,11 @@ describe('useMidiPlayback layering', () => {
         soundSetId: 'rachmaninoff-orchestral-lite',
         layerFamilies: ['piano', 'strings']
       });
+      await Promise.resolve();
+      await Promise.resolve();
     });
 
-    await waitFor(() => {
-      expect(ensureSoundSetLoaded).toHaveBeenCalledWith('rachmaninoff-orchestral-lite');
-    });
+    expect(ensureSoundSetLoaded).toHaveBeenCalledWith('rachmaninoff-orchestral-lite');
 
     await act(async () => {
       vi.runAllTimers();

--- a/sound-engine/frontend/src/utils/midiParser.js
+++ b/sound-engine/frontend/src/utils/midiParser.js
@@ -35,6 +35,7 @@ import { withBase } from './baseUrl.js';
  * @property {string} path - Path to MIDI file
  * @property {string} composer - Composer name
  * @property {string|null} [soundSetId] - Optional built-in sound set id for samples
+ * @property {string[]} [layerFamilies] - Optional forced layer families (e.g. ['piano', 'strings'])
  * @property {string} [sourceUrl] - Optional source URL for MIDI file metadata
  */
 
@@ -128,20 +129,24 @@ export function getBuiltInMidiFiles(base = import.meta.env.BASE_URL) {
       name: 'Piano Concerto No. 2 - I. Moderato',
       path: toBuiltInPath('rachmaninoff-concerto2-mov1.mid'),
       composer: 'Sergei Rachmaninoff',
-      soundSetId: 'rachmaninoff-orchestral-lite'
+      soundSetId: 'rachmaninoff-orchestral-lite',
+      layerFamilies: ['piano', 'strings']
     },
     {
       id: 'rachmaninoff-concerto2-mov2',
       name: 'Piano Concerto No. 2 - II. Adagio',
       path: toBuiltInPath('rachmaninoff-concerto2-mov2.mid'),
       composer: 'Sergei Rachmaninoff',
-      soundSetId: 'rachmaninoff-orchestral-lite'
+      soundSetId: 'rachmaninoff-orchestral-lite',
+      layerFamilies: ['piano', 'strings']
     },
     {
       id: 'rachmaninoff-concerto2-mov3',
       name: 'Piano Concerto No. 2 - III. Allegro',
       path: toBuiltInPath('rachmaninoff-concerto2-mov3.mid'),
-      composer: 'Sergei Rachmaninoff'
+      composer: 'Sergei Rachmaninoff',
+      soundSetId: 'rachmaninoff-orchestral-lite',
+      layerFamilies: ['piano', 'strings']
     },
     // Other pieces
     {

--- a/sound-engine/frontend/src/utils/midiParser.test.js
+++ b/sound-engine/frontend/src/utils/midiParser.test.js
@@ -19,6 +19,17 @@ describe('getBuiltInMidiFiles', () => {
     expect(vocalise?.path).toBe('/midi/rachmaninoff-vocalise.mid');
   });
 
+  it('assigns piano+strings layering metadata to Rachmaninoff concerto files', () => {
+    const files = getBuiltInMidiFiles('/');
+    const rachConcerto = files.filter((file) => file.id.startsWith('rachmaninoff-concerto2-'));
+
+    expect(rachConcerto.length).toBe(3);
+    expect(rachConcerto.every((file) => file.soundSetId === 'rachmaninoff-orchestral-lite')).toBe(true);
+    expect(rachConcerto.every((file) => Array.isArray(file.layerFamilies))).toBe(true);
+    expect(rachConcerto.every((file) => file.layerFamilies.includes('piano'))).toBe(true);
+    expect(rachConcerto.every((file) => file.layerFamilies.includes('strings'))).toBe(true);
+  });
+
   it('maps every built-in entry to a committed midi file', () => {
     const files = getBuiltInMidiFiles('/');
     const testDir = path.dirname(fileURLToPath(import.meta.url));


### PR DESCRIPTION
Add true multi-instrument layering for MIDI playback and set Rachmaninoff pieces to default to piano and strings.

This PR enables richer, layered instrument playback for MIDIs by allowing multiple voices per note (sample and/or waveform layers) and propagates `soundSetId` and `layerFamilies` metadata from MIDI selections to the playback engine. The Rachmaninoff concerto movements are now configured to use a default piano and strings layering.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-70834f45-65cb-42de-a617-00c83274999d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-70834f45-65cb-42de-a617-00c83274999d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

