### PR TITLE
Refine waveform panel and remove starter search

### DIFF
--- a/sound-engine/frontend/src/components/Sidebar/SamplesTab.jsx
+++ b/sound-engine/frontend/src/components/Sidebar/SamplesTab.jsx
@@ -103,7 +103,6 @@ const SamplesTab = ({ onSampleSelect, activeSampleId }) => {
   const [importing, setImporting] = useState(false);
   const [stats, setStats] = useState(null);
   const [error, setError] = useState(null);
-  const [starterSearchQuery, setStarterSearchQuery] = useState('');
   const [starterFamilyFilter, setStarterFamilyFilter] = useState('all');
   const folderInputRef = useRef(null);
   const fileInputRef = useRef(null);
@@ -119,15 +118,13 @@ const SamplesTab = ({ onSampleSelect, activeSampleId }) => {
     return ['all', ...ordered, ...extras];
   }, [starterCatalog]);
   const filteredStarterCatalog = useMemo(() => {
-    const normalizedQuery = starterSearchQuery.trim().toLowerCase();
     return featuredStarterCatalog.filter((item) => {
       if (starterFamilyFilter !== 'all' && item.family !== starterFamilyFilter) {
         return false;
       }
-      if (!normalizedQuery) return true;
-      return `${item.name} ${item.family}`.toLowerCase().includes(normalizedQuery);
+      return true;
     });
-  }, [featuredStarterCatalog, starterFamilyFilter, starterSearchQuery]);
+  }, [featuredStarterCatalog, starterFamilyFilter]);
 
   // Load samples on mount
   useEffect(() => {
@@ -385,14 +382,6 @@ const SamplesTab = ({ onSampleSelect, activeSampleId }) => {
       <div className="samples-tab__section">
         <h3 className="samples-tab__heading">Starter Pack</h3>
         <div className="samples-tab__starter-controls">
-          <input
-            type="search"
-            className="samples-tab__starter-search"
-            placeholder="Find starter sample"
-            value={starterSearchQuery}
-            onChange={(event) => setStarterSearchQuery(event.target.value)}
-            aria-label="Filter starter samples"
-          />
           <div className="samples-tab__starter-families">
             {starterFamilies.map((family) => (
               <button

--- a/sound-engine/frontend/src/components/Sidebar/SamplesTab.test.jsx
+++ b/sound-engine/frontend/src/components/Sidebar/SamplesTab.test.jsx
@@ -45,7 +45,7 @@ describe('SamplesTab starter pack integration', () => {
     }));
   });
 
-  it('filters starter quick-access list by family and search', async () => {
+  it('filters starter quick-access list by family', async () => {
     render(<SamplesTab onSampleSelect={vi.fn()} activeSampleId={null} />);
 
     await waitFor(() => {
@@ -55,9 +55,6 @@ describe('SamplesTab starter pack integration', () => {
     fireEvent.click(screen.getByRole('button', { name: /^reed$/i }));
     expect(screen.getByRole('button', { name: /Bassoon Low/i })).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: /French Horn Low/i })).not.toBeInTheDocument();
-
-    const searchInput = screen.getByLabelText('Filter starter samples');
-    fireEvent.change(searchInput, { target: { value: 'zzz-does-not-exist' } });
-    expect(screen.getByText('No starter samples match this filter.')).toBeInTheDocument();
+    expect(screen.queryByLabelText('Filter starter samples')).not.toBeInTheDocument();
   });
 });

--- a/sound-engine/frontend/src/components/Sidebar/Sidebar.css
+++ b/sound-engine/frontend/src/components/Sidebar/Sidebar.css
@@ -662,27 +662,6 @@
   gap: 8px;
 }
 
-.samples-tab__starter-search {
-  width: 100%;
-  min-height: 34px;
-  border-radius: 10px;
-  border: 1px solid rgba(255, 255, 255, 0.12);
-  background: rgba(255, 255, 255, 0.03);
-  color: rgba(245, 250, 255, 0.88);
-  padding: 8px 10px;
-  font-size: 0.62rem;
-  letter-spacing: 0.04em;
-}
-
-.samples-tab__starter-search::placeholder {
-  color: rgba(196, 212, 229, 0.45);
-}
-
-.samples-tab__starter-search:focus-visible {
-  outline: 2px solid rgba(255, 136, 91, 0.45);
-  outline-offset: 1px;
-}
-
 .samples-tab__starter-families {
   display: flex;
   flex-wrap: wrap;

--- a/sound-engine/frontend/src/components/Sidebar/index.jsx
+++ b/sound-engine/frontend/src/components/Sidebar/index.jsx
@@ -131,7 +131,7 @@ const Sidebar = ({
             <p className="sidebar-panel__subtitle">
               {activeTab === 'midi'
                 ? (currentMidi?.name || 'Library + transport')
-                : (activeSampleId ? 'Sample armed' : 'Select or import a source')
+                : (activeSampleId ? 'Source selected' : 'Select or import a source')
               }
             </p>
           </div>

--- a/sound-engine/frontend/src/styles/controls.css
+++ b/sound-engine/frontend/src/styles/controls.css
@@ -8,7 +8,7 @@
   position: relative;
   width: min(1200px, 95vw);
   display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(0, 2fr);
+  grid-template-columns: clamp(220px, 24vw, 300px) minmax(0, 1fr);
   gap: var(--space-lg);
   padding: var(--space-lg);
   align-items: flex-start;
@@ -72,7 +72,7 @@
 
 /* Waveform Panel */
 .waveform-panel {
-  gap: 20px;
+  gap: 14px;
 }
 
 .panel-subtitle {
@@ -85,18 +85,20 @@
 .waveform-grid {
   display: flex;
   flex-direction: column;
-  gap: var(--space-sm);
+  gap: 10px;
 }
 
 .waveform-button {
-  min-height: 118px;
+  min-height: 68px;
   text-align: left;
-  padding: 18px 20px;
+  padding: 12px 14px;
   font-size: clamp(0.85rem, 1vw, 0.95rem);
   font-weight: 300;
-  letter-spacing: 0.14em;
+  letter-spacing: 0.12em;
   text-transform: uppercase;
-  background-image: repeating-linear-gradient(180deg, rgba(232, 240, 245, 0.26) 0px, rgba(232, 240, 245, 0.06) 24px, rgba(122, 143, 163, 0.12) 48px);
+  display: flex;
+  align-items: center;
+  background-image: linear-gradient(180deg, rgba(232, 240, 245, 0.2) 0%, rgba(122, 143, 163, 0.16) 100%);
   min-width: 44px;
 }
 
@@ -104,7 +106,7 @@
   color: var(--color-text-primary);
   box-shadow: 0 30px 50px rgba(12, 24, 36, 0.32);
   border: 1px solid rgba(255, 255, 255, 0.36);
-  transform: translateY(-6px) scale(1.03);
+  transform: translateY(-2px) scale(1.01);
 }
 
 .panel-footer {


### PR DESCRIPTION
This updates the waveform selector panel layout to use a narrower column and denser waveform rows so the left control area has less empty space.\n\nIn the samples sidebar, it removes the non-functional Starter Pack search input and simplifies filtering to family chips only.\n\nIt also replaces the samples subtitle text "Sample armed" with "Source selected" and updates the affected sidebar test assertions.